### PR TITLE
No malloc.h

### DIFF
--- a/libsharp/sharp_legendre.c
+++ b/libsharp/sharp_legendre.c
@@ -1,4 +1,4 @@
-/* DO NOT EDIT. md5sum of source: d9499375a254cbf1e7903a249a8676ff *//*
+/* DO NOT EDIT. md5sum of source: a8c5c18a7a19c378187dbf461d12eb5c *//*
 
     NOTE NOTE NOTE
 
@@ -64,7 +64,7 @@
 #include "sharp_legendre.h"
 #include "sharp_vecsupport.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 
 
 

--- a/libsharp/sharp_legendre.c.in
+++ b/libsharp/sharp_legendre.c.in
@@ -64,7 +64,7 @@
 #include "sharp_legendre.h"
 #include "sharp_vecsupport.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 
 /*{ for scalar, T in [("double", ""), ("float", "_s")] }*/
 /*{ for cs in range(1, 7) }*/

--- a/runjinja.py
+++ b/runjinja.py
@@ -15,5 +15,5 @@ env = Environment(block_start_string='/*{',
 
 extra_vars = dict(len=len)
 input = sys.stdin.read()
-sys.stdout.write('/* DO NOT EDIT. md5sum of source: %s */' % hashlib.md5(input).hexdigest())
+sys.stdout.write('/* DO NOT EDIT. md5sum of source: %s */' % hashlib.md5(input.encode()).hexdigest())
 sys.stdout.write(env.from_string(input).render(**extra_vars))


### PR DESCRIPTION
sharp_legendre.c.in attempts to include a nonstandard header, malloc.h, not available on all systems. This PR replaces the include with the standard stdlib.h.

It also fixes a python3 incompatibility in runjinja.py. Going forward, more systems can be expected to default "python" to python3.